### PR TITLE
docs: Fix simple typo, maddness -> madness

### DIFF
--- a/dist/keo.js
+++ b/dist/keo.js
@@ -148,7 +148,7 @@ function runTimeout(fun) {
         return setTimeout(fun, 0);
     }
     try {
-        // when when somebody has screwed with setTimeout but no I.E. maddness
+        // when when somebody has screwed with setTimeout but no I.E. madness
         return cachedSetTimeout(fun, 0);
     } catch (e) {
         try {
@@ -171,7 +171,7 @@ function runClearTimeout(marker) {
         return clearTimeout(marker);
     }
     try {
-        // when when somebody has screwed with setTimeout but no I.E. maddness
+        // when when somebody has screwed with setTimeout but no I.E. madness
         return cachedClearTimeout(marker);
     } catch (e) {
         try {


### PR DESCRIPTION
There is a small typo in dist/keo.js.

Should read `madness` rather than `maddness`.

